### PR TITLE
Fixed absence of /etc/default directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,7 @@ install:
 
 	install -d $(DESTDIR)$(SYSTEMD_UNITDIR)
 	install -m 0644 zram.service $(DESTDIR)$(SYSTEMD_UNITDIR)
+
+	install -d $(DESTDIR)$(DEFAULTDIR)
 	install -m 0644 zram $(DESTDIR)$(DEFAULTDIR)
 


### PR DESCRIPTION
fixes theoretical problem if /etc/default directory is absent
