### PR TITLE
Change the path of SYSTEMD_UNITDIR from  /lib/systemd/system to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX ?= /usr
-SYSTEMD_UNITDIR ?= /lib/systemd/system
+SYSTEMD_UNITDIR ?= /usr/lib/systemd/system
 SYSCONFDIR ?= /etc/sysconfig
 VERSION=1.0.0
 SRC_FILES=Makefile README.md zram zram.service zram.spec zramstart zramstat zramstop


### PR DESCRIPTION
Hello, 

I have problems to create the rpm file with the make rpm command on my Fedora 19. 

I receive this error : 


RPM build errors:
    File not found: /home/ataliba/rpmbuild/BUILDROOT/zram-1.0.0-0.fc19.x86_64/usr/lib/systemd/system/zram.service
make: *** [rpm] Error 1
[ataliba@neo FedoraZram]$ vim Makefile 

Reading the Makefile i see an problem because the /lib on Fedora 19 is a symbolic link to /usr/lib 
I change the variable SYSTEMD_UNITDIR to  /usr/lib/systemd/system

and the command make rpm runs without problems. 
