### PR TITLE
Activate service at swap.target

### DIFF
--- a/mkzram.service
+++ b/mkzram.service
@@ -9,4 +9,4 @@ ExecStop=/usr/sbin/zramstop
 Type=oneshot
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=swap.target


### PR DESCRIPTION
I'm using this modification of the service unit that activates the swap alongside all other swaps in the system and earlier in the boot sequence. I think this makes more sense.
