### PR TITLE
Workstation tuning params

### DIFF
--- a/zramstart
+++ b/zramstart
@@ -3,20 +3,25 @@
 num_cpus=$(grep -c processor /proc/cpuinfo)
 [ "$num_cpus" != 0 ] || num_cpus=1
 
-last_cpu=$((num_cpus - 1))
-FACTOR=33
+threads=$((num_cpus * 4))
+last_thread=$((threads - 1))
+FACTOR=200
+
 [ -f /etc/sysconfig/zram ] && source /etc/sysconfig/zram || true
 factor=$FACTOR # percentage
 
 memtotal=$(grep MemTotal /proc/meminfo | awk ' { print $2 } ')
-mem_by_cpu=$(($memtotal/$num_cpus*$factor/100*1024))
-
-modprobe -q zram num_devices=$num_cpus
-
-for i in $(seq 0 $last_cpu); do
-	#enable lz4 if that supported
-	grep -q lz4 /sys/block/zram$i/comp_algorithm && echo lz4 > /sys/block/zram$i/comp_algorithm
-	echo $mem_by_cpu > /sys/block/zram$i/disksize
-	mkswap /dev/zram$i
-	swapon -p 100 /dev/zram$i
+mem_by_cpu=$(($memtotal/$threads*$factor/100*1024))
+modprobe -q zram num_devices=$threads
+for i in $(seq 0 $last_thread); do
+  #enable lz4 if that supported
+  grep -q lz4 /sys/block/zram$i/comp_algorithm && echo lz4 > /sys/block/zram$i/comp_algorithm
+  echo $mem_by_cpu > /sys/block/zram$i/disksize
+  mkswap /dev/zram$i
+  swapon -p 100 /dev/zram$i
 done
+
+echo 100 > /proc/sys/vm/swappiness
+echo 15 > /proc/sys/vm/dirty_ratio
+echo 3 > /proc/sys/vm/dirty_background_ratio
+echo 100000 > /proc/sys/vm/vfs_cache_pressure

--- a/zramstart
+++ b/zramstart
@@ -29,3 +29,6 @@ done
 # vm.swappiness=5
 # ON HDD
 # vm.swappiness=99
+
+# if you having SSD, you may try class 1 (realtime)
+# ionice -c 2 -p `pgrep kswapd0`

--- a/zramstart
+++ b/zramstart
@@ -21,7 +21,11 @@ for i in $(seq 0 $last_thread); do
   swapon -p 100 /dev/zram$i
 done
 
-echo 100 > /proc/sys/vm/swappiness
-echo 15 > /proc/sys/vm/dirty_ratio
-echo 3 > /proc/sys/vm/dirty_background_ratio
-echo 100000 > /proc/sys/vm/vfs_cache_pressure
+# vm.vfs_cache_pressure=50
+# vm.dirty_ratio=30
+# vm.dirty_background_ratio=20
+
+# ON SSD
+# vm.swappiness=5
+# ON HDD
+# vm.swappiness=99

--- a/zramstat
+++ b/zramstat
@@ -2,12 +2,31 @@
 
 ls /sys/block/zram* > /dev/null 2>&1 || exit 0
 
+sum_compr=0
+sum_orig=0
+
+while [ 1 ]; do
+
 for i in /sys/block/zram*; do
-	compr=$(< $i/compr_data_size)
-	orig=$(< $i/orig_data_size)
-	ratio=0
-	if [ $compr -gt 0 ]; then
-		ratio=$(echo "scale=2; $orig*100/$compr" | bc -q)
-	fi
-	echo -e "/dev/${i/*\/}:\t$ratio% ($orig -> $compr)"
+  compr=$(< $i/compr_data_size)
+  orig=$(< $i/orig_data_size)
+  sum_compr=$((sum_compr+compr))
+  sum_orig=$((sum_orig+orig))
+  ratio=0
+  if [ $compr -gt 0 ]; then
+    ratio=$(echo "scale=2; $orig*100/$compr" | bc -q)
+  fi
+# echo -e "/dev/${i/*\/}:\t$ratio% ($orig -> $compr)"
+done
+
+ratio=0
+if [ $sum_compr -gt 0 ]; then
+  ratio=$(echo "scale=2; $sum_orig*100/$sum_compr" | bc -q)
+fi
+sum_orig=$((sum_orig/1024/1024))
+sum_compr=$((sum_compr/1024/1024))
+diff=$((sum_orig-sum_compr))
+
+echo -ne "\t GAINED $diff MB by using $sum_compr MB\r    "
+sleep 1
 done


### PR DESCRIPTION
Zram device capacity counting in "stored data size". And typical compression size its near 3x. So with old settings, you gave only 11% of your ram. I prefer completely disable hdd/ssd swap, and storing compressed pages 2/3 of my RAM. (factor=200)
Actual ram "wasted" = (RAM \* factor  / compress_ratio) = 2/3 RAM

But in case of huge overload (when you active using ~ 1.5 of your RAM), threading is a bottleneck. In such moments processes are sleeping, awaiting for data. So i decided to settup 2 compress threads foreach core.

And at last, only one problem remain. Little freeze on swapout. Including mouse lag. It lasts less than half of minute, but still annoying. It happened when "current using application" unable to find free space, but nothing available. And we awaiting for swapout done.
After tuning `vfs_cache_pressure` we forcing kernel to drop any cache, in such situations. Causing swapout(because memory starvation began), going transparently.

And last of all. We do not want be always in situation of "file cache drop", thats why `swappiness` is on his maximum. It would trying to get at least few megabytes "trully free" memory. Not data, not cache. Those means that we making little "gap" before cache drop.

So about kernel options: prioritize applications, drop disk cache, and avoid stash write(undropable) disk data.
