### PR TITLE
Solve ordering cycle problem

### DIFF
--- a/mkzram.service
+++ b/mkzram.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Enable compressed swap in memory using zram
 After=multi-user.target
+DefaultDependencies=no
 
 [Service]
 RemainAfterExit=yes


### PR DESCRIPTION
CentOS 8.x doesn't start SSH daemon from time to time with mkzram.service installed.

Using:
- systemd-analyze verify default.target
detects ordering cycle problem (journalctl fragment):

systemd[1]: multi-user.target: Found ordering cycle on sshd.service/start
systemd[1]: multi-user.target: Found dependency on sysinit.target/start
systemd[1]: multi-user.target: Found dependency on swap.target/start
systemd[1]: multi-user.target: Found dependency on mkzram.service/start
systemd[1]: multi-user.target: Found dependency on multi-user.target/start
systemd[1]: multi-user.target: Job sshd.service/start deleted to break ordering cycle s....

=> Solution: Don't depend on default dependencies.
